### PR TITLE
fixing ordering problems with the mysql stuffs

### DIFF
--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -1,42 +1,87 @@
 # verify java dependency
-verify_java 'MySQL Plugin'
-
-# check required attributes
-verify_attributes do
-  attributes [
-    'node[:newrelic][:license_key]',
-    'node[:newrelic][:mysql][:install_path]',
-    'node[:newrelic][:mysql][:servers]'
-  ]
+ruby_block "foo" do
+  block do
+    unless node[:languages][:java] && node[:languages][:java][:version].start_with?('1.6', '1.7')
+      Chef::Application.fatal!("The New Relic MySQL Plugin requires a Java version >= 1.6 -" +
+        " For more information, see https://docs.newrelic.com/docs/plugins/installing-a-plugin")
+    end
+  end
 end
 
-verify_license_key node[:newrelic][:license_key]
+# check required attributes
+ruby_block "bar" do
+  block do
+    attributes = [
+      'node[:newrelic][:license_key]',
+      'node[:newrelic][:mysql][:install_path]',
+      'node[:newrelic][:mysql][:servers]'
+    ]
+    missing_attributes = attributes.select { |attribute| eval(attribute).nil? }
+    unless missing_attributes.empty?
+      Chef::Application.fatal!("You must provide the following attributes: #{missing_attributes.join(', ')}. For more information, see <INSERT_URL_HERE>")
+    end
 
-install_plugin 'newrelic_mysql_plugin' do
-  plugin_version   node[:newrelic][:mysql][:version]
-  install_path     node[:newrelic][:mysql][:install_path]
-  download_url     node[:newrelic][:mysql][:download_url]
+    unless /^[0-9a-fA-F]{40}$/ =~ node['newrelic']['license_key']
+      Chef::Application.fatal!("The provided New Relic License Key is invalid: #{node['newrelic']['license_key']}. For more information, see https://docs.newrelic.com/docs/subscriptions/license-key")
+    end
+  end
+end
+
+file_name      = "newrelic_mysql_plugin-#{node['newrelic']['mysql']['version']}"
+plugin_path    = "#{node['newrelic']['mysql']['install_path']}/#{file_name}"
+download_path  = "#{plugin_path}.tar.gz"
+
+# create install path
+directory node['newrelic']['mysql']['install_path'] do
+  action :create
+end
+
+# download plugin tar file
+remote_file download_path do
+  source node['newrelic']['mysql']['download_url']
+  action :create_if_missing
+  not_if { File.directory?(plugin_path) }
+end
+
+# extract plugin tar file
+bash "extract newrelic_mysql_plugin resource" do
+  cwd node['newrelic']['mysql']['install_path']
+  code <<-EOH
+    tar zxvf #{download_path}
+  EOH
+  not_if { File.directory?(plugin_path) }
 end
 
 # create template newrelic.properties file
-template "#{node[:newrelic][:mysql][:plugin_path]}/config/newrelic.properties" do
+template "#{node['newrelic']['mysql']['install_path']}/newrelic_mysql_plugin-#{node['newrelic']['mysql']['version']}/config/newrelic.properties" do
   source 'mysql/newrelic.properties.erb'
   action :create
   notifies :restart, "service[newrelic-mysql-plugin]"
 end
 
 # create template mysql.instance.json file
-template "#{node[:newrelic][:mysql][:plugin_path]}/config/mysql.instance.json" do
+template "#{node['newrelic']['mysql']['install_path']}/newrelic_mysql_plugin-#{node['newrelic']['mysql']['version']}/config/mysql.instance.json" do
   source 'mysql/mysql.instance.json.erb'
   action :create
   notifies :restart, "service[newrelic-mysql-plugin]"
 end
 
 # install init.d script and start service
-plugin_service 'newrelic-mysql-plugin' do
-  daemon          'newrelic_mysql_plugin*.jar'
-  daemon_dir      node[:newrelic][:mysql][:plugin_path]
-  plugin_name     'MySQL'
-  plugin_version  node[:newrelic][:mysql][:version]
-  run_command     "java #{node[:newrelic][:mysql][:java_options]} -jar"
+template "/etc/init.d/newrelic-mysql-plugin" do
+  source 'service.erb'
+  variables({
+    :daemon =>       'newrelic_mysql_plugin*.jar',
+    :daemon_dir =>   "#{node['newrelic']['mysql']['install_path']}/newrelic_mysql_plugin-#{node['newrelic']['mysql']['version']}",
+    :plugin_name =>  'MySQL',
+    :run_command =>  "java #{node['newrelic']['mysql']['java_options']} -jar",
+    :service_name => 'newrelic-mysql-plugin',
+    :version =>      node['newrelic']['mysql']['version']
+  })
+  action :create
+  mode 0755
+end
+
+# manage service
+service "newrelic-mysql-plugin" do
+  action [:enable, :start]
 end


### PR DESCRIPTION
There were issues with the ordering done within chef.

For instance, since everything was done in ruby blocks it was pushed to compile time within chef.  So even if I called the java cookbook to install java (and I did) it would never run, because the check java cookbook would fail out.

Basically, running everything at compile time is bad :D

This is just an example of code that worked for me, this cookbook likely needs to be refactored.
