### PR TITLE
making verify java/ruby run at execution time instead of compile time

### DIFF
--- a/definitions/verify_java.rb
+++ b/definitions/verify_java.rb
@@ -1,7 +1,14 @@
 define :verify_java do
-  # check java dependency
-  unless node[:languages][:java] && node[:languages][:java][:version].start_with?('1.6', '1.7')
-    Chef::Application.fatal!("The New Relic #{params[:name]} requires a Java version >= 1.6 -" +
-      " For more information, see https://docs.newrelic.com/docs/plugins/installing-a-plugin")
+  ohai "reload" do
+    action :reload
+  end
+  ruby_block "verify java for #{params[:name]}" do
+    block do
+      # check java dependency
+      unless node[:languages][:java] && node[:languages][:java][:version].start_with?('1.6', '1.7')
+        Chef::Application.fatal!("The New Relic #{params[:name]} requires a Java version >= 1.6 -" +
+          " For more information, see https://docs.newrelic.com/docs/plugins/installing-a-plugin")
+      end
+    end
   end
 end

--- a/definitions/verify_ruby.rb
+++ b/definitions/verify_ruby.rb
@@ -1,8 +1,15 @@
 define :verify_ruby do
-  # check ruby dependency - exclude chef's embedded ruby
-  unless node[:languages][:ruby] && node[:languages][:ruby][:version].start_with?('1.8.7', '1.9', '2.0') &&
-    node[:languages][:ruby][:ruby_bin] !~ /chef/
-    Chef::Application.fatal!("The New Relic #{params[:name]} requires a Ruby version >= 1.8.7 -" +
-      " For more information, see https://docs.newrelic.com/docs/plugins/installing-a-plugin")
+  ohai "reload" do
+    action :reload
+  end
+  ruby_block "verify ruby for #{params[:name]}" do
+    block do
+      # check ruby dependency - exclude chef's embedded ruby
+      unless node[:languages][:ruby] && node[:languages][:ruby][:version].start_with?('1.8.7', '1.9', '2.0') &&
+        node[:languages][:ruby][:ruby_bin] !~ /chef/
+        Chef::Application.fatal!("The New Relic #{params[:name]} requires a Ruby version >= 1.8.7 -" +
+          " For more information, see https://docs.newrelic.com/docs/plugins/installing-a-plugin")
+      end
+    end
   end
 end


### PR DESCRIPTION
@lars2893 

FYI: @prometheanfire

The verify java and ruby steps were running at compile time which could prevent someone from having the java recipe first in the run list before the mysql plugin recipe. These new changes move the verification of java and ruby to execution time.
