### PR TITLE
Create plugin directory recursively

### DIFF
--- a/definitions/install_plugin.rb
+++ b/definitions/install_plugin.rb
@@ -4,8 +4,9 @@ define :install_plugin do
 
   # create install path
   directory params[:install_path] do
-    action :create
     owner params[:user]
+    action :create
+    recursive true
   end
 
   # download plugin tar file


### PR DESCRIPTION
Some users may wish to install their plugins in a directory that would require recursive directory creation. An example of this would be `/opt/newrelic/plugin`. Adding a simple `recursive true` to the directory creation block will make this possible.
