### PR TITLE
Implementation of Rackspace Queues monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,42 @@ For additional info, see https://github.com/newrelic-platform/newrelic_mysql_jav
 
 For additional info, see https://github.com/newrelic-platform/newrelic_rackspace_load_balancers_plugin
 
+## Rackspace Queues ##
+
+`node[:newrelic][:license_key]` - _(required)_ New Relic License Key
+
+`node[:newrelic][:rackspace_queues][:install_path]` -  _(required)_ Install directory. Defaults to `/opt/newrelic`. The plugin will be installed within this directory at `newrelic_rackspace_queues_plugin`.
+
+`node[:newrelic][:rackspace_queues][:user]` - _(required)_ User to run as.
+
+`node[:newrelic][:rackspace_queues][:username]` - _(required)_ Username for Rackspace Queues
+
+`node[:newrelic][:rackspace_queues][:api_key]` - _(required)_ API Key for Rackspace Queues
+
+`node[:newrelic][:rackspace_queues][:region]` - _(required)_ Region for Rackspace Queues. Valid values: `ord`, `dfw`, or `lon`
+
+#### Usage: ####
+
+    name "newrelic_rackspace_queues_plugin"
+    description "System that monitors Rackspace Queues"
+    run_list(
+      "recipe[newrelic_plugins::rackspace_queues]"
+    )
+    default_attributes(
+      "newrelic" => {
+        "license_key" => "NEW_RELIC_LICENSE_KEY",
+        "rackspace_queues" => {
+          "install_path" => "/path/to/plugin",
+          "user"         => "newrelic",
+          "username"     => "RACKSPACE_USERNAME",
+          "api_key"      => "RACKSPACE_API_KEY",
+          "region"       => "dfw"
+        }
+      }
+    )
+
+For additional info, see https://github.com/newrelic-platform/newrelic_rackspace_load_balancers_plugin
+
 ## Wikipedia Example Java Plugin
 
 #### Attributes: ####

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,13 @@ default[:newrelic][:rackspace_load_balancers][:download_url] = "https://github.c
 default[:newrelic][:rackspace_load_balancers][:install_path] = "/opt/newrelic"
 default[:newrelic][:rackspace_load_balancers][:plugin_path] = "#{node[:newrelic][:rackspace_load_balancers][:install_path]}/newrelic_rackspace_load_balancers_plugin"
 
+# rackspace queues attributes
+default[:newrelic][:rackspace_queues][:version] = "1.2.0-fork"
+# see PR https://github.com/newrelic-platform/newrelic_rackspace_load_balancers_plugin/pull/8
+default[:newrelic][:rackspace_queues][:download_url] = "https://github.com/newrelic-platform/newrelic_rackspace_load_balancers_plugin/archive/#{node[:newrelic][:rackspace_queues][:version]}.tar.gz"
+default[:newrelic][:rackspace_queues][:install_path] = "/opt/newrelic"
+default[:newrelic][:rackspace_queues][:plugin_path] = "#{node[:newrelic][:rackspace_queues][:install_path]}/newrelic_rackspace_queues_plugin"
+
 # wikipedia example java plugin attributes
 default[:newrelic][:wikipedia_example_java][:version] = "1.0.8"
 default[:newrelic][:wikipedia_example_java][:download_url] = "https://github.com/newrelic-platform/newrelic_java_wikipedia_plugin/raw/master/dist/newrelic_wikipedia_plugin-#{node[:newrelic][:wikipedia_example_java][:version]}.tar.gz"

--- a/recipes/rackspace_queues.rb
+++ b/recipes/rackspace_queues.rb
@@ -1,0 +1,58 @@
+# verify ruby dependency
+verify_ruby 'Rackspace Queues Plugin'
+
+# check required attributes
+verify_attributes do
+  attributes [
+    'node[:newrelic][:license_key]', 
+    'node[:newrelic][:rackspace_queues][:install_path]', 
+    'node[:newrelic][:rackspace_queues][:user]',
+    'node[:newrelic][:rackspace_queues][:username]',
+    'node[:newrelic][:rackspace_queues][:api_key]',
+    'node[:newrelic][:rackspace_queues][:region]'
+  ]
+end
+
+verify_license_key node[:newrelic][:license_key]
+
+# nokogiri dependencies - debian vs rhel
+if platform_family?('debian')
+  package 'libxml2-dev'
+  package 'libxslt-dev'
+else
+  package 'libxml2'
+  package 'libxml2-devel'
+  package 'libxslt'
+  package 'libxslt-devel'
+end
+
+install_plugin 'newrelic_rackspace_queues_plugin' do
+  plugin_version   node[:newrelic][:rackspace_queues][:version]
+  install_path     node[:newrelic][:rackspace_queues][:install_path]
+  plugin_path      node[:newrelic][:rackspace_queues][:plugin_path]
+  download_url     node[:newrelic][:rackspace_queues][:download_url]
+  user             node[:newrelic][:rackspace_queues][:user]
+end
+
+# newrelic template
+template "#{node[:newrelic][:rackspace_queues][:plugin_path]}/config/newrelic_plugin.yml" do
+  source 'rackspace_queues/newrelic_plugin.yml.erb'
+  action :create
+  owner node[:newrelic][:rackspace_queues][:user]
+  notifies :restart, 'service[newrelic-rackspace-queues-plugin]'
+end
+
+# install bundler gem and run 'bundle install'
+bundle_install do
+  path node[:newrelic][:rackspace_queues][:plugin_path]
+  user node[:newrelic][:rackspace_queues][:user]
+end
+
+# install init.d script and start service
+plugin_service 'newrelic-rackspace-queues-plugin' do
+  daemon          './bin/newrelic_rs'
+  daemon_dir      node[:newrelic][:rackspace_queues][:plugin_path]
+  plugin_name     'Rackspace Queues'
+  plugin_version  node[:newrelic][:rackspace_queues][:version]
+  run_command     "sudo -u #{node[:newrelic][:rackspace_queues][:user]} bundle exec"
+end

--- a/templates/default/rackspace_queues/newrelic_plugin.yml.erb
+++ b/templates/default/rackspace_queues/newrelic_plugin.yml.erb
@@ -1,0 +1,24 @@
+# Please make sure to update the license_key information with the
+# license key for your New Relic account.
+#
+newrelic:
+  #
+  # Update with your New Relic account license key:
+  #
+  license_key: '<%= node[:newrelic][:license_key] %>'
+  #
+  # Set to '1' for verbose output, remove for normal output.
+  # All output goes to stdout/stderr.
+  #
+  # verbose: 1
+#
+# Rackspace configuration.
+#
+rackspace:
+  username: '<%= node[:newrelic][:rackspace_queues][:username] %>'
+  api_key: '<%= node[:newrelic][:rackspace_queues][:api_key] %>'
+  region: '<%= node[:newrelic][:rackspace_queues][:region] %>'
+
+agents:
+  rackspace_q:
+    enabled: true


### PR DESCRIPTION
Implementation of Rackspace Queues monitoring - please do clean up the version and download_url, depending on the direction taken for https://github.com/newrelic-platform/newrelic_rackspace_load_balancers_plugin/pull/8.

Thanks in advance for merging these PRs and getting Rackspace Queues-monitoring implemented in the newrelic-platform/newrelic_plugins_chef cookbook!

Kind regards,
David
