### PR TITLE
Renamed install_plugin definition to prevent conflict

### DIFF
--- a/definitions/newrelic_plugin.rb
+++ b/definitions/newrelic_plugin.rb
@@ -1,4 +1,4 @@
-define :install_plugin do
+define :newrelic_plugin do
 
   tar_file = File.join(params[:install_path], "#{params[:name]}-#{params[:plugin_version]}.tar.gz")
 

--- a/recipes/aws_cloudwatch.rb
+++ b/recipes/aws_cloudwatch.rb
@@ -26,7 +26,7 @@ else
   package 'libxslt-devel'
 end
 
-install_plugin 'newrelic_aws_cloudwatch_plugin' do
+newrelic_plugin 'newrelic_aws_cloudwatch_plugin' do
   plugin_version   node[:newrelic][:aws_cloudwatch][:version]
   install_path     node[:newrelic][:aws_cloudwatch][:install_path]
   plugin_path      node[:newrelic][:aws_cloudwatch][:plugin_path]

--- a/recipes/example.rb
+++ b/recipes/example.rb
@@ -12,7 +12,7 @@ end
 
 verify_license_key node[:newrelic][:license_key]
 
-install_plugin 'newrelic_example_plugin' do
+newrelic_plugin 'newrelic_example_plugin' do
   plugin_version   node[:newrelic][:example][:version]
   install_path     node[:newrelic][:example][:install_path]
   plugin_path      node[:newrelic][:example][:plugin_path]

--- a/recipes/memcached_java.rb
+++ b/recipes/memcached_java.rb
@@ -13,7 +13,7 @@ end
 
 verify_license_key node[:newrelic][:license_key]
 
-install_plugin 'newrelic_memcached_java_plugin' do
+newrelic_plugin 'newrelic_memcached_java_plugin' do
   plugin_version   node[:newrelic][:memcached_java][:version]
   install_path     node[:newrelic][:memcached_java][:install_path]
   plugin_path      node[:newrelic][:memcached_java][:plugin_path]

--- a/recipes/memcached_ruby.rb
+++ b/recipes/memcached_ruby.rb
@@ -12,7 +12,7 @@ end
 
 verify_license_key node[:newrelic][:license_key]
 
-install_plugin 'newrelic_memcached_ruby_plugin' do
+newrelic_plugin 'newrelic_memcached_ruby_plugin' do
   plugin_version   node[:newrelic][:memcached_ruby][:version]
   install_path     node[:newrelic][:memcached_ruby][:install_path]
   plugin_path      node[:newrelic][:memcached_ruby][:plugin_path]

--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -13,7 +13,7 @@ end
 
 verify_license_key node[:newrelic][:license_key]
 
-install_plugin 'newrelic_mysql_plugin' do
+newrelic_plugin 'newrelic_mysql_plugin' do
   plugin_version   node[:newrelic][:mysql][:version]
   install_path     node[:newrelic][:mysql][:install_path]
   plugin_path      node[:newrelic][:mysql][:plugin_path]

--- a/recipes/rackspace_load_balancers.rb
+++ b/recipes/rackspace_load_balancers.rb
@@ -26,7 +26,7 @@ else
   package 'libxslt-devel'
 end
 
-install_plugin 'newrelic_rackspace_load_balancers_plugin' do
+newrelic_plugin 'newrelic_rackspace_load_balancers_plugin' do
   plugin_version   node[:newrelic][:rackspace_load_balancers][:version]
   install_path     node[:newrelic][:rackspace_load_balancers][:install_path]
   plugin_path      node[:newrelic][:rackspace_load_balancers][:plugin_path]

--- a/recipes/wikipedia_example_java.rb
+++ b/recipes/wikipedia_example_java.rb
@@ -12,7 +12,7 @@ end
 
 verify_license_key node[:newrelic][:license_key]
 
-install_plugin 'newrelic_wikipedia_example_java_plugin' do
+newrelic_plugin 'newrelic_wikipedia_example_java_plugin' do
   plugin_version   node[:newrelic][:wikipedia_example_java][:version]
   install_path     node[:newrelic][:wikipedia_example_java][:install_path]
   plugin_path      node[:newrelic][:wikipedia_example_java][:plugin_path]

--- a/recipes/wikipedia_example_ruby.rb
+++ b/recipes/wikipedia_example_ruby.rb
@@ -12,7 +12,7 @@ end
 
 verify_license_key node[:newrelic][:license_key]
 
-install_plugin 'newrelic_wikipedia_example_ruby_plugin' do
+newrelic_plugin 'newrelic_wikipedia_example_ruby_plugin' do
   plugin_version   node[:newrelic][:wikipedia_example_ruby][:version]
   install_path     node[:newrelic][:wikipedia_example_ruby][:install_path]
   plugin_path      node[:newrelic][:wikipedia_example_ruby][:plugin_path]


### PR DESCRIPTION
Hi,
I've tried to use the newrelic_plugin and it worked well. However As soon I've added an other cookbook(elasticsearch) to my metadata it failed.

It's coming from a conflict between the definition `install_plugin` in [newrelic_plugin_chef](https://github.com/newrelic-platform/newrelic_plugins_chef/blob/master/definitions/install_plugin.rb) and the `install_plugin` method from [elasticsearch cookbook](https://github.com/elasticsearch/cookbook-elasticsearch/blob/master/libraries/install_plugin.rb).

`recipes/mysql.rb` was trying to install a plugin but it was actually calling the elasticsearch method, therefore I got errors like this : 

```
Chef::Exceptions::ResourceNotFound:
       resource ruby_block[Install plugin: newrelic_mysql_plugin] is configured to notify resource service[elasticsearch] with action restart, but service[elasticsearch] cannot be found in the resource collection. ruby_block[Install plugin: newrelic_mysql_plugin] is defined in /var/folders/0p/l33795bn35ng4f_6p_7sqtbm2tcccx/T/d20141103-22587-13abh3b/cookbooks/elasticsearch/libraries/install_plugin.rb:35:in `install_plugin'
```

I've not been able to find a better solution than to rename the definition in newrelic_plugins_chef. It's a small change, and should prevent any further conflict.

It's a big blocker for us, and I guess it would be for other people too.

Thank you!
